### PR TITLE
多端适配，解决<aiocqhttp.exceptions.ApiNotAvailable>报错

### DIFF
--- a/bili_notice_hoshino.py
+++ b/bili_notice_hoshino.py
@@ -37,7 +37,11 @@ async def bili_watch():
 
             msg = f'{dyinfo["nickname"]} {dytype}, 点击链接直达：\n {dyinfo["link"]}  \n[CQ:image,file={dyinfo["pic"]}]'
             for gid in dyinfo["group"]:
-                await bot.send_group_msg(group_id=gid, message=msg)
+                for sid in hoshino.get_self_ids():
+                    try:
+                        await bot.send_group_msg(self_id = sid, group_id=gid, message=msg)
+                    except Exception as e:
+                        sv.logger.info(f'bot账号{sid}不在群{gid}中，将忽略该消息')
                 time.sleep(1)
         time.sleep(5)
 


### PR DESCRIPTION
- 当多cqgo端连接同一个bot后端时，会造成分群推送消息异常报错，故修复该问题
## 错误日志：
```
[2022-07-14 01:14:50,531 b站动态监视器] ERROR: <class 'aiocqhttp.exceptions.ApiNotAvailable'> occured when doing scheduled job bili_watch.
[2022-07-14 01:14:50,531 b站动态监视器] ERROR: 
Traceback (most recent call last):
  File "C:\Users\Administrator\qqbot\HoshinoBot\hoshino\service.py", line 349, in wrapper
    ret = await func()
  File "C:\Users\Administrator\qqbot\HoshinoBot\hoshino\modules\bili-notice-hoshino\bili_notice_hoshino.py", line 40, in bili_watch
    await bot.send_group_msg(group_id=gid, message=msg)
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python38\lib\site-packages\aiocqhttp\__init__.py", line 238, in call_action
    return await self._api.call_action(action=action, **params)
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python38\lib\site-packages\aiocqhttp\api_impl.py", line 191, in call_action
    raise ApiNotAvailable
aiocqhttp.exceptions.ApiNotAvailable
```
## 解决办法
如pr所提交的代码所示。
该方法已用于解决pcrjjc2、pcrjjc3-tw等插件的多端推送报错问题，实测有效，解决办法参考自咖啡佬的星乃自带的分群广播功能。